### PR TITLE
Chinese languages translation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,11 @@ These features no longer apply to the latest version of this plugin:
 | `en` | English | Intermediate | [Omel](https://www.spigotmc.org/members/omel.85850/) | `>= 1.0, < 1.4` |
 | `de` | German | Native | [bleeding182](https://github.com/bleeding182) | `>= 1.10.2` |
 | `nl` | Dutch | Native | [SBDeveloper](https://github.com/stijnb1234), \_\_Dutch\_\_ | `>= 1.11.1` |
-| `zh` | Simplified Chinese | Intermediate | [Aobi](https://github.com/AobiYT) | `>= 1.11.4` |
+| `zh` | Simplified Chinese | Intermediate | [eason329](https://github.com/eason329) | `>= 1.11.4` |
 | `zh` | Simplified Chinese | Machine Translation | [Deltik](https://git.io/Deltik) | `>= 1.10.2, < 1.11.4` |
-| `zh-CN` | Simplified Chinese | Intermediate | [Aobi](https://github.com/AobiYT) | `>= 1.11.4` |
-| `zh-TW` | Traditional Chinese | Intermediate | [Aobi](https://github.com/AobiYT) | `>= 1.11.4` |
+| `zh-CN` | Simplified Chinese | Intermediate | [eason329](https://github.com/eason329) | `>= 1.11.4` |
+| `zh-HK` | Hong Kong Cantonese | Native | [eason329](https://github.com/eason329) | `not released` |
+| `zh-TW` | Traditional Chinese | Intermediate | [eason329](https://github.com/eason329) | `>= 1.11.4` |
 
 ### Visual Examples
 

--- a/src/resources/Comms_zh.properties
+++ b/src/resources/Comms_zh.properties
@@ -57,77 +57,77 @@ usage_page_numbering=\\ {secondary}{0,number}{reset}{primaryDark}/{1,number}
 ## 2 - Subcommand arguments
 print_subcommand_usage={primary}/{0} {primaryLight}{1} {primaryDark}{2}
 ## 0 - {online_documentation_url}
-online_documentation={secondary}{strong}在线帮助：{reset}{0}
+online_documentation={secondary}{strong}在线帮助： {reset}{0}
 online_documentation_url=https://git.io/SignEdit-README
 sign_did_not_change={primary}告示牌没有变更。
 ## 0 - {section_decorator}, only shown if there is something to say about the section
-before_section={primary}{strong}变更前：{0}
+before_section={primary}{strong}变更前： {0}
 ## 0 - {section_decorator}, only shown if there is something to say about the section
-after_section={primary}{strong}变更后：{0}
+after_section={primary}{strong}变更后： {0}
 ## 0 - A notice about the section
 section_decorator={reset}{primaryDark}{italic}（{primaryLight}{italic}{0}{primaryDark}{italic}）
 right_click_sign_to_apply_action={primary}右键点击要编辑的告示牌
 right_click_sign_to_apply_action_hint=\\ {italic}右键点击要编辑的告示牌
 right_click_air_to_apply_action_hint=\\ {italic}对空气点击右键以执行动作
-right_click_air_to_open_sign_editor={primary}请将视线移离告示牌，然后点击右键以开启告示牌编辑器
+right_click_air_to_open_sign_editor={primary}请将视线移离告示牌， 然后点击右键， 开启告示牌编辑器
 sign_editor_item_name=告示牌编辑器
 must_look_at_sign_to_interact={error}你必须看着一个告示牌才能编辑它！
-lines_copied_section={primary}{strong}已复制的行：
-lines_cut_section={primary}{strong}已剪下的行：
+lines_copied_section={primary}{strong}已复制的行： 
+lines_cut_section={primary}{strong}已剪下的行： 
 cancelled_pending_action={primary}等待中的编辑动作已取消。
 no_pending_action_to_cancel={error}没有可以取消的编辑动作！
 # StatusSignSubcommand
-no_pending_action=没有
-empty_clipboard={primaryDark}没有
+no_pending_action=无
+empty_clipboard={primaryDark}空白
 ## 0 - One of the "Interactions"
-pending_action_section={primary}{strong}等待中的动作：{reset}{0}
+pending_action_section={primary}{strong}等待中的动作： {reset}{0}
 ## 0 - {history_have}
-history_section={primary}{strong}编辑历史：{reset}{0}
+history_section={primary}{strong}编辑历史： {reset}{0}
 ## 0 - Count of items in the undo stack
 ## 1 - Count of items in the redo stack
 history_have={primary}有 {primaryLight}{0,number}{primary} 个撤销和 {primaryLight}{1,number}{primary} 个重做
 ## 0 - {empty_clipboard}, shown only if the clipboard is empty
-clipboard_contents_section={primary}{strong}剪贴板內容：{reset}{0}
+clipboard_contents_section={primary}{strong}剪贴板內容： {reset}{0}
 # Interactions
 copy_sign_text=复制告示牌的文字
-cut_sign_text=剪下告示牌的文字
-paste_lines_from_clipboard=贴上剪贴板里的文字
+cut_sign_text=剪切告示牌的文字
+paste_lines_from_clipboard=粘贴剪贴板里的文字
 change_sign_text=更改告示牌的文字
 open_sign_editor=开启告示牌编辑器
 # VersionSignSubcommand
 ## 0 - Version of the plugin
 version={primary}版本 {secondary}{0}
 # Errors
-forbidden_sign_edit={error}不能编辑这个告示牌，因為有其他东西阻止了编辑。
+forbidden_sign_edit={error}不能编辑这个告示牌， 因為有其他东西阻止了编辑。
 missing_line_selection_exception={error}必须至少选择一个行。
 ## 0 - Invalid input that the player tried to pass as a line selection
 number_parse_line_selection_exception={error}"{0}" 不是一个正确的行号。
 ## 0 - The index of the first line of a sign
 ## 1 - The index of the last line of a sign
 ## 2 - The invalid line index that the player inputted
-out_of_bounds_line_selection_exception={error}行号必须在 {0,number} 到 {1,number} 之间，却提供了 {2,number}。
+out_of_bounds_line_selection_exception={error}行号必须在 {0,number} 到 {1,number} 之间， 却提供了 {2,number}。
 ## 0 - The invalid lower bound that the player inputted for a line range selection
 ## 1 - The invalid upper bound that the player inputted for a line range selection
 ## 2 - The invalid line range selection that the player inputted
-range_order_line_selection_exception={error}在选择 {2} 中，下限 {0,number} 不能高于上限 {1,number}。
+range_order_line_selection_exception={error}在选择 {2} 中， 下限 {0,number} 不能高于上限 {1,number}。
 ## 0 - The invalid line range selection that the player inputted
 ## 1 - The full invalid line selection that the player inputted
-range_parse_line_selection_exception={error}在选择 {1} 中，"{0}" 并非有效的范围。
+range_parse_line_selection_exception={error}在选择 {1} 中， "{0}" 并非有效的范围。
 nothing_to_undo={error}没有可以撤销的动作
 nothing_to_redo={error}没有可以重做的动作
-block_state_not_placed_exception={error}命令执行失败：告示牌已不再存在！
+block_state_not_placed_exception={error}命令执行失败： 告示牌已不再存在！
 null_clipboard_exception={error}剪贴板是空的！
 ## 0 - The string representation of a Java Exception
-uncaught_error={error}未知的错误：{0}
+uncaught_error={error}未知的错误： {0}
 cannot_open_sign_editor={error}{strong}无法开启告示牌编辑器！
 ## 0 - The guessed cause of a sign edit failure, probably {minecraft_server_api_changed}
-likely_cause={primaryDark}可能的原因：{reset}{0}
-minecraft_server_api_changed=Minecraft服务器 API 改变了
+likely_cause={primaryDark}可能的原因： {reset}{0}
+minecraft_server_api_changed=Minecraft 服务器 API 改变了
 ## 0 - A message for the player to forward to the server admin
-to_server_admin={primaryDark}服务器管理员：{reset}{0}
+to_server_admin={primaryDark}服务器管理员： {reset}{0}
 check_for_updates_to_this_plugin=检查这个插件的更新
 ## 0 - The string representation of a Java Exception
-error_code={primaryDark}错误代码：{reset}{0}
+error_code={primaryDark}错误代码： {reset}{0}
 hint_more_details_with_server_admin={error}（服务器的控制台有更多信息）
 # Warnings
 modified_by_another_plugin=已被其他插件编辑

--- a/src/resources/Comms_zh_HK.properties
+++ b/src/resources/Comms_zh_HK.properties
@@ -42,7 +42,7 @@ print_line=\\ {0}＜{1,number}＞{reset} {2}
 # General
 plugin_name=SignEdit
 ## 0 - Command and subcommand as "/command subcommand"
-you_cannot_use={error}你沒有權限使用 {primaryLight}{0}{error}。
+you_cannot_use={error}你冇權限使用 {primaryLight}{0}{error}。
 ## 0 - {usage_page_info}
 usage_page_heading={secondary}-----{reset} {0}{reset} {secondary}-----
 ## 0 - Command
@@ -57,77 +57,77 @@ usage_page_numbering=\\ {secondary}{0,number}{reset}{primaryDark}/{1,number}
 ## 2 - Subcommand arguments
 print_subcommand_usage={primary}/{0} {primaryLight}{1} {primaryDark}{2}
 ## 0 - {online_documentation_url}
-online_documentation={secondary}{strong}線上說明： {reset}{0}
+online_documentation={secondary}{strong}線上説明： {reset}{0}
 online_documentation_url=https://git.io/SignEdit-README
-sign_did_not_change={primary}告示牌沒有變更。
+sign_did_not_change={primary}告示牌未有變更。
 ## 0 - {section_decorator}, only shown if there is something to say about the section
 before_section={primary}{strong}變更前： {0}
 ## 0 - {section_decorator}, only shown if there is something to say about the section
 after_section={primary}{strong}變更後： {0}
 ## 0 - A notice about the section
 section_decorator={reset}{primaryDark}{italic}（{primaryLight}{italic}{0}{primaryDark}{italic}）
-right_click_sign_to_apply_action={primary}右鍵點擊要編輯的告示牌
-right_click_sign_to_apply_action_hint=\\ {italic}右鍵點擊要編輯的告示牌
+right_click_sign_to_apply_action={primary}右鍵點擊要編輯嘅告示牌
+right_click_sign_to_apply_action_hint=\\ {italic}右鍵點擊要編輯嘅告示牌
 right_click_air_to_apply_action_hint=\\ {italic}對空氣點擊右鍵以執行操作
-right_click_air_to_open_sign_editor={primary}請將視線移離告示牌， 然後點擊右鍵， 開啟告示牌編輯器
+right_click_air_to_open_sign_editor={primary}請將視線移離告示牌， 然後點擊右鍵， 打開告示牌編輯器
 sign_editor_item_name=告示牌編輯器
-must_look_at_sign_to_interact={error}你必須看著一個告示牌才能編輯它！
-lines_copied_section={primary}{strong}已複製的行： 
-lines_cut_section={primary}{strong}已剪下的行： 
-cancelled_pending_action={primary}等待中的編輯操作已取消。
-no_pending_action_to_cancel={error}沒有可以取消的編輯操作！
+must_look_at_sign_to_interact={error}你必須睇住一個告示牌先可以編輯！
+lines_copied_section={primary}{strong}已複製嘅行： 
+lines_cut_section={primary}{strong}已剪下嘅行： 
+cancelled_pending_action={primary}等待中嘅編輯動作已取消。
+no_pending_action_to_cancel={error}未有可以取消嘅編輯操作！
 # StatusSignSubcommand
 no_pending_action=無
 empty_clipboard={primaryDark}空白
 ## 0 - One of the "Interactions"
-pending_action_section={primary}{strong}等待中的操作： {reset}{0}
+pending_action_section={primary}{strong}等待中嘅操作： {reset}{0}
 ## 0 - {history_have}
 history_section={primary}{strong}編輯歷史： {reset}{0}
 ## 0 - Count of items in the undo stack
 ## 1 - Count of items in the redo stack
-history_have={primary}有 {primaryLight}{0,number}{primary} 個撤銷和 {primaryLight}{1,number}{primary} 個重做
+history_have={primary}有 {primaryLight}{0,number}{primary} 個撤銷同 {primaryLight}{1,number}{primary} 個重做
 ## 0 - {empty_clipboard}, shown only if the clipboard is empty
 clipboard_contents_section={primary}{strong}剪貼簿內容： {reset}{0}
 # Interactions
-copy_sign_text=複製告示牌的文字
-cut_sign_text=剪下告示牌的文字
-paste_lines_from_clipboard=貼上剪貼簿裡的文字
-change_sign_text=更改告示牌的文字
+copy_sign_text=複製告示牌嘅文字
+cut_sign_text=剪下告示牌嘅文字
+paste_lines_from_clipboard=貼上剪貼簿入邊嘅文字
+change_sign_text=更改告示牌嘅文字
 open_sign_editor=開啟告示牌編輯器
 # VersionSignSubcommand
 ## 0 - Version of the plugin
 version={primary}版本 {secondary}{0}
 # Errors
-forbidden_sign_edit={error}不能編輯這個告示牌， 因為有其他東西阻止了編輯。
+forbidden_sign_edit={error}唔可以編輯依個告示牌， 因為有其他嘢阻止咗編輯。
 missing_line_selection_exception={error}必須至少選擇一個行。
 ## 0 - Invalid input that the player tried to pass as a line selection
-number_parse_line_selection_exception={error}"{0}" 不是一個正確的行號。
+number_parse_line_selection_exception={error}"{0}" 唔係一個正確嘅行號。
 ## 0 - The index of the first line of a sign
 ## 1 - The index of the last line of a sign
 ## 2 - The invalid line index that the player inputted
-out_of_bounds_line_selection_exception={error}行號必須在 {0,number} 至 {1,number} 之間， 卻提供了 {2,number}。
+out_of_bounds_line_selection_exception={error}行號必須喺 {0,number} 至 {1,number} 之間， 但提供咗 {2,number}。
 ## 0 - The invalid lower bound that the player inputted for a line range selection
 ## 1 - The invalid upper bound that the player inputted for a line range selection
 ## 2 - The invalid line range selection that the player inputted
-range_order_line_selection_exception={error}在選擇 {2} 中， 下限 {0,number} 不能高於上限 {1,number}。
+range_order_line_selection_exception={error}喺選擇 {2} 中， 下限 {0,number} 唔可以高過上限 {1,number}。
 ## 0 - The invalid line range selection that the player inputted
 ## 1 - The full invalid line selection that the player inputted
-range_parse_line_selection_exception={error}在選擇 {1} 中， "{0}" 並非有效的範圍。
-nothing_to_undo={error}沒有可以撤銷的操作
-nothing_to_redo={error}沒有可以重做的操作
-block_state_not_placed_exception={error}指令執行失敗： 告示牌已不再存在！
-null_clipboard_exception={error}剪貼簿是空的！
+range_parse_line_selection_exception={error}喺選擇 {1} 中， "{0}" 並非有效嘅範圍。
+nothing_to_undo={error}未有可以撤銷嘅操作
+nothing_to_redo={error}未有可以重做嘅操作
+block_state_not_placed_exception={error}指令執行失敗： 告示牌已唔再存在！
+null_clipboard_exception={error}剪貼簿係空白嘅！
 ## 0 - The string representation of a Java Exception
-uncaught_error={error}不明的錯誤： {0}
-cannot_open_sign_editor={error}{strong}無法開啟告示牌編輯器！
+uncaught_error={error}不明嘅錯誤： {0}
+cannot_open_sign_editor={error}{strong}無法打開告示牌編輯器！
 ## 0 - The guessed cause of a sign edit failure, probably {minecraft_server_api_changed}
-likely_cause={primaryDark}可能的原因： {reset}{0}
-minecraft_server_api_changed=Minecraft 伺服器 API 改變了
+likely_cause={primaryDark}可能嘅原因： {reset}{0}
+minecraft_server_api_changed=Minecraft 伺服器 API 改變咗
 ## 0 - A message for the player to forward to the server admin
 to_server_admin={primaryDark}伺服器管理員： {reset}{0}
-check_for_updates_to_this_plugin=檢查這個插件的更新
+check_for_updates_to_this_plugin=檢查依個插件嘅更新
 ## 0 - The string representation of a Java Exception
 error_code={primaryDark}錯誤代碼： {reset}{0}
-hint_more_details_with_server_admin={error}（伺服器的控制台有更多訊息）
+hint_more_details_with_server_admin={error}（伺服器嘅控制台有更多訊息）
 # Warnings
 modified_by_another_plugin=已被其他插件編輯


### PR DESCRIPTION
## Purpose
Chinese language translation improvement, and make this plugin supports most of Chinese variants available in Minecraft (except Classical Chinese).

## Purposed Changes
- Modify Chinese (Traditional) (zh-TW) and Chinese (Simplified) (zh-CN) translation
- Add Hong Kong Cantonese (zh-HK) translation
> Although this language is called 「繁體中文（香港）」when it is added in 1.17, it uses lots of Cantonese characters. To reduce confusion, I used Cantonese instead of Chinese (Hong Kong)
- Add a space after colon (︰) and comma (，) as their full width form is not properly shown in Minecraft's chat
- Change my GitHub username for `Supported Locales` in readme

## PS
For proposed zh-HK, I set the Version in `Supported Locales` as "not released" , please change the Version upon the release of new translation.

The proficiency level of zh-CN and zh-TW remains "Intermediate" as they still need being proofread by other native Chinese speaker.

<s>Also, I have not test the new language yet, so I will mark this PR as draft at the moment.</s>